### PR TITLE
reduce namespace pollution, solves https://github.com/rjbs/stick/issues/3

### DIFF
--- a/lib/Stick/Role/Collection.pm
+++ b/lib/Stick/Role/Collection.pm
@@ -11,6 +11,7 @@ use Stick::Types qw(PositiveInt);
 use Stick::Util qw(ppack);
 use POSIX qw(ceil);
 use Scalar::Util qw(blessed);
+use namespace::autoclean -also => [ qw(Any ArrayRef Maybe is_Maybe Object Str is_Str Undef PositiveInt is_PositiveInt) ];
 
 require Stick::Publisher;
 use Stick::Publisher::Publish;

--- a/lib/Stick/Role/Collection/HasFilters.pm
+++ b/lib/Stick/Role/Collection/HasFilters.pm
@@ -1,6 +1,7 @@
 package Stick::Role::Collection::HasFilters;
 use Moose::Role;
 use MooseX::Types::Moose qw(ArrayRef CodeRef);
+use namespace::autoclean -also => [ qw(ArrayRef CodeRef is_ArrayRef) ];
 
 # filters return true or false
 # an item is in the collection only if *all* filters return true

--- a/lib/Stick/Role/HasCollection.pm
+++ b/lib/Stick/Role/HasCollection.pm
@@ -1,5 +1,6 @@
 package Stick::Role::HasCollection;
 # ABSTRACT: A class which owns a (routable) collection of objects
+use namespace::autoclean;
 use Stick::Types qw(Factory);
 use Stick::Util qw(class);
 use MooseX::Role::Parameterized;


### PR DESCRIPTION
I'm not really happy with the hack job I put in to fix this, but it solves the namespace pollution problems that appear _today_. Plain `use namespace::autoclean` did not do the job.
