### PR TITLE
Throw error on duplicate method names

### DIFF
--- a/lib/Stick/Publisher/Publish.pm
+++ b/lib/Stick/Publisher/Publish.pm
@@ -22,6 +22,13 @@ sub publish {
 
   my $package = $caller->name;
 
+  # Throw an error if the method we're trying to publish already exists in the
+  # package to which we're trying to install. Moose's MOP will happily add a new
+  # method in that replaces the existing method of the same name.
+  if ($caller->has_method($name)) {
+    Stick::Error->throw("method '$name' already exists in package '$package'");
+  }
+
   my $sig = {};
   my $arg = {};
 

--- a/t/lib/PTest/DuplicateMethods.pm
+++ b/t/lib/PTest/DuplicateMethods.pm
@@ -1,0 +1,17 @@
+package PTest::File::DuplicateMethods;
+use Moose;
+
+use Stick::Publisher;
+use Stick::Publisher::Publish;
+use namespace::autoclean;
+
+publish original => {} => sub {
+  return 0;
+};
+
+publish original => {} => sub {
+  return 1;
+};
+
+no Moose;
+1;

--- a/t/route/duplicate.t
+++ b/t/route/duplicate.t
@@ -1,0 +1,28 @@
+use strict;
+use warnings;
+use Test::Deep qw(cmp_deeply any array_each bool ignore);
+use Test::More;
+use Test::Fatal;
+
+use lib 't/lib';
+
+use Scalar::Util qw(blessed);
+
+subtest "duplicate method fails" => sub {
+  my $exc = exception {
+    require PTest::DuplicateMethods;
+    my $test = PTest::DuplicateMethods->new(filename => 'foo')
+  };
+
+  ok($exc, "we got an exception on a duplicate method");
+
+  like(
+    $exc,
+    qr{method '\w+' already exists in package '},
+    "we get a reasonable error message"
+  );
+
+};
+
+
+done_testing;


### PR DESCRIPTION
Moose's MOP has no problem adding a method with the same name as one
that already exists. Since you probably don't want to publish two
different methods with the same name, this throws an error instead.

If you really want to override it, you could call
`$class->remove_method($name)` first.